### PR TITLE
export, custom check, help

### DIFF
--- a/biosmount.sh
+++ b/biosmount.sh
@@ -1,27 +1,43 @@
 #!/bin/bash
 #
 # Quickly mount the external drive you want to pull your bios from
-
-mountpoint=~/mnt/drive2
-
 display_help() {
 echo Usage: biosmount [options]
 echo  options:
-echo   -m, manually select a mount point. Otherwise, defaults to ~/mnt/drive2
-echo   -h, display this help page 
+echo   "-m <path>, manually select a mount point. Otherwise, defaults to "$HOME"/mnt/drive2"
+echo   "-h, display this help page"
 
+echo "The first time you run biosmount, or if you set a new mount point, you must run it in your parent shell, or gpuflash won't work! Do this by running as . ./biosmount.sh"
 
 }
 
 while getopts "hm:" flag; do
     case "${flag}" in
-        m) mountpoint=${OPTARG} ;;
+        m) globalbiosmountpoint=${OPTARG}
+           custom='true' ;;
         h) display_help 
            exit ;;
         *) echo "Unexpected flag. Try -h for help" 
            exit ;;
     esac
 done
+
+if [[ -z "$globalbiosmountpoint" ]]
+then
+    globalbiosmountpoint="$HOME"/mnt/drive2
+    echo "Setting mount point as ("$globalbiosmountpoint")"
+    echo "Unless this is your first run, the mount point might not be globally set"
+    echo "Please make sure to ran this script in your parent shell. See -h"
+    echo ""
+elif [[ -n "$globalbiosmountpoint" && "$custom" = 'true' ]]
+then
+    echo "Setting mount point as "$globalbiosmountpoint""
+    echo "Make sure you ran this script in your parent shell. See -h"
+else
+    echo "The mount point is "$globalbiosmountpoint""
+fi
+
+export globalbiosmountpoint
 
 echo Select the drive to mount:
 
@@ -31,14 +47,14 @@ read -e -p 'Drive: ' biosdrive #drive name, e.g. sdb1
 
 drivetype=$(blkid -o value -s TYPE /dev/"$biosdrive")
 
-if [ ! -d "$mountpoint" ]
+if [ ! -d "$globalbiosmountpoint" ]
 then
     echo Creating mount point...
-    sudo mkdir -p "$mountpoint"
+    sudo mkdir -p "$globalbiosmountpoint"
 else
-    echo Mount point "$mountpoint" exists...
+    echo Mount point "$globalbiosmountpoint" exists...
 fi
 
 echo OK, mounting "$biosdrive"
 
-sudo mount -t "$drivetype" /dev/"$biosdrive" "$mountpoint"
+sudo mount -t "$drivetype" /dev/"$biosdrive" "$globalbiosmountpoint"


### PR DESCRIPTION
Truly export the mount point variable, and warn the user if it thinks it might not be running in the parent shell (or if they set a custom mount point)
Better listening for custom set
Cleaned up tilde, since they're having trouble expanding. Replaced with $HOME, a sturdier variable
Expanded display_help